### PR TITLE
Refactored Router to be a non-static class

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: PHP Composer
 
 on:
   push:
-    branches: *
+    branches: [ * ]
   pull_request:
-    branches: *
+    branches: [ * ]
 
 permissions:
   contents: read

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: PHP Composer
 
 on:
   push:
-    branches: [ "main" ]
+    branches: *
   pull_request:
-    branches: [ "main" ]
+    branches: *
 
 permissions:
   contents: read

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,11 @@ name: PHP Composer
 
 on:
   push:
-    branches: [ * ]
+    branches:
+      - '**'
   pull_request:
-    branches: [ * ]
+    branches:
+      - '**'
 
 permissions:
   contents: read

--- a/src/Router.php
+++ b/src/Router.php
@@ -27,115 +27,115 @@ class Router
     /**
      * @var Route[]
      */
-    protected static array $routes = [];
-    protected static array $group = [];
-    protected static int $emitHttpExceptions = 0;
+    protected array $routes = [];
+    protected array $group = [];
+    protected int $emitHttpExceptions = 0;
 
     /**
      * @var Route[][]
      */
-    protected static array $catchers = [];
+    protected array $catchers = [];
 
-    public static function get(string $uri, string $controller): Route
+    public function get(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, Methods::GET);
+        $route = new Route($this, $uri, $controller, Methods::GET);
 
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
-    public static function post(string $uri, string $controller): Route
+    public function post(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, Methods::POST);
+        $route = new Route($this, $uri, $controller, Methods::POST);
 
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
-    public static function put(string $uri, string $controller): Route
+    public function put(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, Methods::PUT);
+        $route = new Route($this, $uri, $controller, Methods::PUT);
 
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
-    public static function patch(string $uri, string $controller): Route
+    public function patch(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, Methods::PATCH);
+        $route = new Route($this, $uri, $controller, Methods::PATCH);
 
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
-    public static function delete(string $uri, string $controller): Route
+    public function delete(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, Methods::DELETE);
+        $route = new Route($this, $uri, $controller, Methods::DELETE);
 
-        self::addRoute($route);
-
-        return $route;
-    }
-
-
-    public static function options(string $uri, string $controller): Route
-    {
-        $route = new Route($uri, $controller, Methods::OPTIONS);
-
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
 
-    public static function head(string $uri, string $controller): Route
+    public function options(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, Methods::HEAD);
+        $route = new Route($this, $uri, $controller, Methods::OPTIONS);
 
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
 
-    public static function all(string $uri, string $controller): Route
+    public function head(string $uri, string $controller): Route
     {
-        $route = new Route($uri, $controller, ...Methods::cases());
+        $route = new Route($this, $uri, $controller, Methods::HEAD);
 
-        self::addRoute($route);
+        $this->addRoute($route);
 
         return $route;
     }
 
 
-    public static function addRoute(Route $route): void
+    public function all(string $uri, string $controller): Route
     {
-        if (isset(self::$group)) {
-            foreach (self::$group["middlewares"] ?? [] as $middlware) {
+        $route = new Route($this, $uri, $controller, ...Methods::cases());
+
+        $this->addRoute($route);
+
+        return $route;
+    }
+
+
+    public function addRoute(Route $route): void
+    {
+        if (isset($this->group)) {
+            foreach ($this->group["middlewares"] ?? [] as $middlware) {
                 $route->addMiddleware($middlware);
             }
 
-            foreach (self::$group["postwares"] ?? [] as $postware) {
+            foreach ($this->group["postwares"] ?? [] as $postware) {
                 $route->addPostware($postware);
             }
 
-            foreach (self::$group["parameters"] ?? [] as $name => $value) {
+            foreach ($this->group["parameters"] ?? [] as $name => $value) {
                 $route->setParameter($name, $value);
             }
 
-            foreach (self::$group["staticArguments"] ?? [] as $name => $value) {
+            foreach ($this->group["staticArguments"] ?? [] as $name => $value) {
                 $route->addStaticArgument($name, $value);
             }
         }
 
-        self::$routes[] = &$route;
+        $this->routes[] = &$route;
     }
 
-    public static function group(
+    public function group(
         string $baseUri,
         Closure $grouping,
         array $middlewares = [],
@@ -143,26 +143,26 @@ class Router
         array $parameters = [],
         array $staticArguments = []
     ): void {
-        $oldMount = self::$group;
+        $oldMount = $this->group;
 
-        if (empty(self::getBaseUri())) {
-            self::$group = compact("baseUri", "middlewares", "postwares", "parameters", "staticArguments");
+        if (empty($this->getBaseUri())) {
+            $this->group = compact("baseUri", "middlewares", "postwares", "parameters", "staticArguments");
         } else {
-            self::$group['baseUri'] .= $baseUri;
-            self::$group['middlewares'] = [...self::$group['middlewares'], ...$middlewares];
-            self::$group['postwares'] = [...self::$group['postwares'], ...$postwares];
-            self::$group['parameters'] = [...self::$group['parameters'], ...$parameters];
-            self::$group['staticArguments'] = [...self::$group['staticArguments'], ...$staticArguments];
+            $this->group['baseUri'] .= $baseUri;
+            $this->group['middlewares'] = [...$this->group['middlewares'], ...$middlewares];
+            $this->group['postwares'] = [...$this->group['postwares'], ...$postwares];
+            $this->group['parameters'] = [...$this->group['parameters'], ...$parameters];
+            $this->group['staticArguments'] = [...$this->group['staticArguments'], ...$staticArguments];
         }
 
         $grouping();
 
-        self::$group = $oldMount;
+        $this->group = $oldMount;
     }
 
-    public static function getBaseUri(): string
+    public function getBaseUri(): string
     {
-        return self::$group["baseUri"] ?? "";
+        return $this->group["baseUri"] ?? "";
     }
 
     /**
@@ -170,7 +170,7 @@ class Router
      * @param ServerRequestInterface $request
      * @return ResolvedRoute|null
      */
-    protected static function resolveRoute(array $routes, ServerRequestInterface $request): ?ResolvedRoute
+    protected function resolveRoute(array $routes, ServerRequestInterface $request): ?ResolvedRoute
     {
         $routeMatches = static function (Route $route, string $requestUri, ?array &$matches) use (&$argNames): bool {
             $argNames = [];
@@ -230,62 +230,62 @@ class Router
         return $resolvedRoute ?? null;
     }
 
-    public static function catch(string $toCatch, string $controller, ?string $uri = "/(.*)"): Route
+    public function catch(string $toCatch, string $controller, ?string $uri = "/(.*)"): Route
     {
-        $catchable = array_keys(self::$catchers);
+        $catchable = array_keys($this->catchers);
 
         if (!in_array($toCatch, $catchable)) {
-            self::makeCatchable($toCatch);
+            $this->makeCatchable($toCatch);
         }
 
-        $route = new Route($uri, $controller, ...Methods::cases());
+        $route = new Route($this, $uri, $controller, ...Methods::cases());
 
-        self::$catchers[$toCatch][] = &$route;
+        $this->catchers[$toCatch][] = &$route;
 
         return $route;
     }
 
-    public static function makeCatchable(string $toCatch): void
+    public function makeCatchable(string $toCatch): void
     {
-        if (!isset(self::$catchers[$toCatch])) {
+        if (!isset($this->catchers[$toCatch])) {
             if (!is_subclass_of($toCatch, HttpException::class)) {
                 throw new InvalidArgumentException("{$toCatch} must extend " . HttpException::class);
             }
 
-            self::$catchers[$toCatch] = [];
+            $this->catchers[$toCatch] = [];
         }
     }
 
     /**
      * @return Route[]
      */
-    public static function getRoutes(bool $sort = true): array
+    public function getRoutes(bool $sort = true): array
     {
         if ($sort) {
-            self::sortRoutesAndCatchers();
+            $this->sortRoutesAndCatchers();
         }
 
-        return self::$routes;
+        return $this->routes;
     }
 
     /**
      * @return Route[][]
      */
-    public static function getCatchers(bool $sort = true): array
+    public function getCatchers(bool $sort = true): array
     {
         if ($sort) {
-            self::sortRoutesAndCatchers();
+            $this->sortRoutesAndCatchers();
         }
 
-        return self::$catchers;
+        return $this->catchers;
     }
 
-    public static function emitHttpExceptions(int $type): void
+    public function emitHttpExceptions(int $type): void
     {
-        self::$emitHttpExceptions = $type;
+        $this->emitHttpExceptions = $type;
     }
 
-    protected static function invokeRoute(
+    protected function invokeRoute(
         ResolvedRoute $resolvedRoute,
         ServerRequestInterface $request
     ): ResponseInterface {
@@ -321,55 +321,55 @@ class Router
         return $next($request, $response, $resolvedRoute->args);
     }
 
-    protected static function sortRoutesAndCatchers(): void
+    protected function sortRoutesAndCatchers(): void
     {
         $sortByLength = static function (Route $a, Route $b) {
             return (strlen($a->uri) > strlen($b->uri));
         };
 
-        foreach (self::$catchers as &$catcher) {
+        foreach ($this->catchers as &$catcher) {
             usort($catcher, $sortByLength);
         }
 
         unset($catcher);
 
-        usort(self::$routes, $sortByLength);
+        usort($this->routes, $sortByLength);
     }
 
-    public static function clearRoutes(): void
+    public function clearRoutes(): void
     {
-        self::$routes = [];
+        $this->routes = [];
     }
 
-    public static function clearCatchers(): void
+    public function clearCatchers(): void
     {
-        self::$catchers = [];
+        $this->catchers = [];
     }
 
-    public static function clearAll(): void
+    public function clearAll(): void
     {
-        self::clearRoutes();
-        self::clearCatchers();
+        $this->clearRoutes();
+        $this->clearCatchers();
     }
 
-    public static function run(?ServerRequestInterface $request = null, ?EmitterInterface $emitter = null): void
+    public function run(?ServerRequestInterface $request = null, ?EmitterInterface $emitter = null): void
     {
         $emitter ??= new SapiEmitter();
-        $routes = self::getRoutes();
-        $catchers = self::getCatchers(false);
+        $routes = $this->getRoutes();
+        $catchers = $this->getCatchers(false);
         $request ??= ServerRequestCreator::createFromGlobals();
-        $resolved = self::resolveRoute($routes, $request);
+        $resolved = $this->resolveRoute($routes, $request);
 
         try {
             if ($resolved === null) {
                 throw new Exceptions\HttpNotFound($request);
             }
 
-            $response = self::invokeRoute($resolved, $request);
+            $response = $this->invokeRoute($resolved, $request);
         } catch (Throwable $e) {
             $resolved = array_key_exists($e::class, $catchers) ?
-                self::resolveRoute($catchers[$e::class], $request) :
-                self::resolveRoute($catchers[HttpInternalServerError::class] ?? [], $request)
+                $this->resolveRoute($catchers[$e::class], $request) :
+                $this->resolveRoute($catchers[HttpInternalServerError::class] ?? [], $request)
             ;
 
             if ($resolved === null) {
@@ -379,7 +379,7 @@ class Router
 
                 $class = $e::class;
 
-                $method = match (self::$emitHttpExceptions) {
+                $method = match ($this->emitHttpExceptions) {
                     self::EMIT_HTML_RESPONSE => "buildHtmlResponse",
                     self::EMIT_JSON_RESPONSE => "buildJsonResponse",
                     default => "buildEmptyResponse"
@@ -390,7 +390,7 @@ class Router
 
             if (!isset($response)) {
                 $resolved->args->exception = $e;
-                $response = self::invokeRoute($resolved, $request);
+                $response = $this->invokeRoute($resolved, $request);
             }
         }
 

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -49,9 +49,9 @@ class Route
         $this->methods = $methods;
     }
 
-    public static function new(string $uri, string $controller, Methods ...$methods): self
+    public static function new(Router $router, string $uri, string $controller, Methods ...$methods): self
     {
-        return new self($uri, $controller, ...$methods);
+        return new self($router, $uri, $controller, ...$methods);
     }
 
     public function getParameter(string $name): ?string

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -30,11 +30,11 @@ class Route
      * @param class-string<RequestHandlerInterface> $controller
      * @param Methods                               ...$methods
      */
-    public function __construct(string $uri, public readonly string $controller, Methods ...$methods)
+    public function __construct(protected readonly Router $router, string $uri, public readonly string $controller, Methods ...$methods)
     {
-        if (!str_starts_with($uri, "/") && empty(Router::getBaseUri())) {
+        if (!str_starts_with($uri, "/") && empty($this->router->getBaseUri())) {
             $uri = "/{$uri}";
-        } elseif (!empty(Router::getBaseUri()) && str_ends_with($uri, "/")) {
+        } elseif (!empty($this->router->getBaseUri()) && str_ends_with($uri, "/")) {
             $uri = substr($uri, 0, -1);
         }
 
@@ -42,7 +42,7 @@ class Route
             throw new InvalidArgumentException("{$controller} must implement " . RequestHandlerInterface::class);
         }
 
-        $this->uri = Router::getBaseUri() . $uri;
+        $this->uri = $this->router->getBaseUri() . $uri;
 
         $this->parameters = new stdClass();
 

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -26,12 +26,17 @@ class Route
     private stdClass $parameters;
 
     /**
-     * @param string                                $uri
+     * @param Router $router
+     * @param string $uri
      * @param class-string<RequestHandlerInterface> $controller
-     * @param Methods                               ...$methods
+     * @param Methods ...$methods
      */
-    public function __construct(protected readonly Router $router, string $uri, public readonly string $controller, Methods ...$methods)
-    {
+    public function __construct(
+        protected readonly Router $router,
+        string $uri,
+        public readonly string $controller,
+        Methods ...$methods
+    ) {
         if (!str_starts_with($uri, "/") && empty($this->router->getBaseUri())) {
             $uri = "/{$uri}";
         } elseif (!empty($this->router->getBaseUri()) && str_ends_with($uri, "/")) {
@@ -49,8 +54,12 @@ class Route
         $this->methods = $methods;
     }
 
-    public static function new(Router $router, string $uri, string $controller, Methods ...$methods): self
-    {
+    public static function new(
+        Router $router,
+        string $uri,
+        string $controller,
+        Methods ...$methods
+    ): self {
         return new self($router, $uri, $controller, ...$methods);
     }
 
@@ -67,7 +76,7 @@ class Route
     }
 
     /**
-     * @param  class-string<RequestHandlerInterface> ...$middlewares
+     * @param class-string<RequestHandlerInterface> ...$middlewares
      * @return self
      */
     public function addMiddleware(string ...$middlewares): self
@@ -84,7 +93,7 @@ class Route
     }
 
     /**
-     * @param  class-string<RequestHandlerInterface> ...$postwares
+     * @param class-string<RequestHandlerInterface> ...$postwares
      * @return self
      */
     public function addPostware(string ...$postwares): self

--- a/tests/RouteTests.php
+++ b/tests/RouteTests.php
@@ -5,13 +5,23 @@ namespace Tests\Tnapf\Router;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Tnapf\Router\Enums\Methods;
+use Tnapf\Router\Router;
 use Tnapf\Router\Routing\Route;
 
 class RouteTests extends TestCase
 {
+    protected Router $router;
+
+    public function __construct(string $name)
+    {
+        parent::__construct($name);
+
+        $this->router = new Router();
+    }
+
     public function createBasicRoute(Methods...$methods): Route
     {
-        return new Route("home", TestController::class, ...$methods);
+        return new Route($this->router, "home", TestController::class, ...$methods);
     }
 
     public function testRoutePrependsMissingStartingSlash(): void
@@ -24,7 +34,7 @@ class RouteTests extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new Route("/", "InvalidController");
+        new Route($this->router, "/", "InvalidController");
     }
 
     public function testRouteSettingGettingParameters(): void

--- a/tests/RouteTests.php
+++ b/tests/RouteTests.php
@@ -27,7 +27,7 @@ class RouteTests extends TestCase
     public function testRoutePrependsMissingStartingSlash(): void
     {
         $route = $this->createBasicRoute();
-        $this->assertEquals("/home", $route->uri, "Route should prepend missing starting slash");
+        $this->assertSame("/home", $route->uri, "Route should prepend missing starting slash");
     }
 
     public function testRouteRejectsInvalidController(): void
@@ -41,9 +41,9 @@ class RouteTests extends TestCase
     {
         $route = $this->createBasicRoute();
         $route->setParameter("id", "\d+");
-        $this->assertEquals("(\d+)", $route->getParameter("id"), "Route should set parameter");
+        $this->assertSame("(\d+)", $route->getParameter("id"), "Route should set parameter");
 
-        $this->assertEquals("{invalid}", $route->getParameter("invalid"), "Route should return the parameter name if it doesn't exist");
+        $this->assertSame("{invalid}", $route->getParameter("invalid"), "Route should return the parameter name if it doesn't exist");
     }
 
     public function testRouteAddingPostware(): void


### PR DESCRIPTION
# Why?
In attempts to make all of the libraries in TNAPF comply with PSR and be usable in any circumstance. It only makes sense to convert Router into a non-static class so it can be used with PSR-15. Which will be implemented soon